### PR TITLE
APNs: Use timestamp based on TTL instead of the TTL itself

### DIFF
--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -49,7 +49,7 @@ pub fn send_push(
     // Note: This will swallow any errors when converting to a timestamp
     let expiration: Option<u64> = match ttl {
         0 => Some(0),
-        _ => {
+        ttl => {
             let now = SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .expect("Could not retrieve UNIX timestamp");

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -2,6 +2,7 @@
 //!
 use std::convert::Into;
 use std::io::Read;
+use std::time::Duration;
 
 use a2::CollapseId;
 use a2::client::{Client, Endpoint};
@@ -43,12 +44,12 @@ pub fn send_push(
     version: u16,
     session: &str,
     collapse_id: Option<CollapseId>,
-    ttl: u32,
+    ttl_timestamp: Option<Duration>,
 ) -> SendFuture<(), SendPushError> {
     // Notification options
     let options = NotificationOptions {
         apns_id: None,
-        apns_expiration: Some(u64::from(ttl)),
+        apns_expiration: ttl_timestamp.map(|timestamp| timestamp.as_secs()),
         apns_priority: Priority::High,
         apns_topic: Some(bundle_id),
         apns_collapse_id: collapse_id,

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -2,7 +2,7 @@
 //!
 use std::convert::Into;
 use std::io::Read;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use a2::CollapseId;
 use a2::client::{Client, Endpoint};
@@ -44,12 +44,24 @@ pub fn send_push(
     version: u16,
     session: &str,
     collapse_id: Option<CollapseId>,
-    ttl_timestamp: Option<Duration>,
+    ttl: u32,
 ) -> SendFuture<(), SendPushError> {
+    // Note: This will swallow any errors when converting to a timestamp
+    let expiration: Option<u64> = match ttl {
+        0 => Some(0),
+        _ => {
+            let now = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .expect("Could not retrieve UNIX timestamp");
+            now.checked_add(Duration::from_secs(u64::from(ttl)))
+                .map(|expiration| expiration.as_secs())
+        },
+    };
+
     // Notification options
     let options = NotificationOptions {
         apns_id: None,
-        apns_expiration: ttl_timestamp.map(|timestamp| timestamp.as_secs()),
+        apns_expiration: expiration,
         apns_priority: Priority::High,
         apns_topic: Some(bundle_id),
         apns_collapse_id: collapse_id,

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,7 +2,6 @@ use std::convert::Into;
 use std::net::SocketAddr;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime};
 
 use a2::CollapseId;
 use a2::client::{Client as ApnsClient, Endpoint};
@@ -262,11 +261,6 @@ impl Service for PushHandler {
                     // No TTL value was specified
                     None => TTL_DEFAULT,
                 };
-                // Note: This will swallow any errors when converting to a timestamp
-                let ttl_timestamp: Option<Duration> = SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .ok()
-                    .and_then(|now| now.checked_add(Duration::from_secs(u64::from(ttl))));
                 let collapse_key: Option<String> = find!("collapse_key")
                     .map(|key| format!("{}.{}", COLLAPSE_KEY_PREFIX, key));
                 let (bundle_id, endpoint, collapse_id) = match push_token {
@@ -322,7 +316,7 @@ impl Service for PushHandler {
                         version,
                         &session_public_key,
                         collapse_id,
-                        ttl_timestamp,
+                        ttl,
                     ),
                 };
 


### PR DESCRIPTION
:smiley_cat:

Depends on #24 