### PR TITLE
Fine-granular error handling

### DIFF
--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -68,15 +68,51 @@ pub fn send_push(
             .send(payload)
             .map(|response| debug!("Success details: {:?}", response))
             .map_err(|error| {
-                // Treat "bad device token" errors as client errors
                 if let A2Error::ResponseError(ref resp) = error {
                     if let Some(ref body) = resp.error {
                         trace!("Response body: {:?}", body);
-                        if body.reason == ErrorReason::BadDeviceToken {
-                            return SendPushError::ProcessingClientError(
-                                "Push was unsuccessful: Bad device token".to_string()
-                            );
-                        }
+                        match body.reason {
+                            // Invalid device token
+                            ErrorReason::BadDeviceToken |
+                            ErrorReason::Unregistered |
+                            // Invalid expiration date (invalid TTL)
+                            ErrorReason::BadExpirationDate |
+                            // Invalid topic (bundle id)
+                            ErrorReason::BadTopic |
+                            ErrorReason::DeviceTokenNotForTopic |
+                            ErrorReason::TopicDisallowed => {
+                                return SendPushError::ProcessingClientError(
+                                    format!("Push was unsuccessful: {}", error));
+                            },
+
+                            // Below errors should never happen
+                            ErrorReason::BadCollapseId |
+                            ErrorReason::BadMessageId |
+                            ErrorReason::BadPriority |
+                            ErrorReason::DuplicateHeaders |
+                            ErrorReason::Forbidden |
+                            ErrorReason::IdleTimeout |
+                            ErrorReason::MissingDeviceToken |
+                            ErrorReason::MissingTopic |
+                            ErrorReason::PayloadEmpty |
+                            ErrorReason::BadCertificate |
+                            ErrorReason::BadCertificateEnvironment |
+                            ErrorReason::ExpiredProviderToken |
+                            ErrorReason::InvalidProviderToken |
+                            ErrorReason::MissingProviderToken |
+                            ErrorReason::BadPath |
+                            ErrorReason::MethodNotAllowed |
+                            ErrorReason::PayloadTooLarge |
+                            ErrorReason::TooManyProviderTokenUpdates => {
+                                error!("Unexpected APNs error response: {}", error);
+                            },
+
+                            // APNs server errors
+                            ErrorReason::TooManyRequests |
+                            ErrorReason::InternalServerError |
+                            ErrorReason::ServiceUnavailable |
+                            ErrorReason::Shutdown => {}
+                        };
                     }
                 }
 

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -169,9 +169,11 @@ pub fn send_push(
                     Some("MismatchSenderId") => SendPushError::ProcessingClientError("Push was unsuccessful: Mismatched sender ID".into()),
                     Some("MessageTooBig") => SendPushError::ProcessingClientError("Push was unsuccessful: Message too big".into()),
                     Some("InvalidDataKey") => SendPushError::ProcessingClientError("Push was unsuccessful: Invalid data key".into()),
+                    Some("InvalidTtl") => SendPushError::ProcessingClientError("Push was unsuccessful: Invalid TTL".into()),
                     Some("Unavailable") => SendPushError::ProcessingRemoteError("Push was unsuccessful: Timeout".into()),
                     Some("InternalServerError") => SendPushError::ProcessingRemoteError("Push was unsuccessful: Internal server error".into()),
                     Some("DeviceMessageRateExceeded") => SendPushError::ProcessingRemoteError("Push was unsuccessful: Device message rate exceeded".into()),
+                    Some("TopicsMessageRateExceeded") => SendPushError::ProcessingRemoteError("Push was unsuccessful: Topics message rate exceeded".into()),
                     Some(other) => SendPushError::Other(format!("Push was unsuccessful: {}", other)),
                     None => SendPushError::Other("Push was unsuccessful".into()),
                 })


### PR DESCRIPTION
This moves a couple of errors to client errors which indicate that the client should abort the attempt to push with the same parameters.