### PR TITLE
Add affiliation id

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The payload format looks like this:
 
 - `wcs`: Webclient session (sha256 hash of the public permanent key of the
   initiator), `string`
+- `wca`: An optional identifier for affiliating consecutive pushes, `string` or `null`
 - `wct`: Unix epoch timestamp of the request in seconds, `i64`
 - `wcv`: Protocol version, `u16`
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Request keys:
 - `token`: The device push token
 - `session`: SHA256 hash of public permanent key of the initiator
 - `version`: Threema Web protocol version
+- `affiliation` (optional): An identifier for affiliating consecutive pushes
 - `ttl` (optional): The lifespan of a push message, defaults to 90 seconds
 - `collapse_key`: (optional) A parameter identifying a group of push messages that can be
   collapsed.

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::stutter)]
 #![allow(clippy::non_ascii_literal)]
 #![allow(clippy::match_same_arms)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate log;

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -43,6 +43,7 @@ pub fn send_push(
     bundle_id: &str,
     version: u16,
     session: &str,
+    affiliation: Option<&str>,
     collapse_id: Option<CollapseId>,
     ttl: u32,
 ) -> SendFuture<(), SendPushError> {
@@ -69,7 +70,7 @@ pub fn send_push(
 
     // Notification payload
     let mut payload = SilentNotificationBuilder::new().build(&*push_token.0, options);
-    let data = ThreemaPayload::new(session, version);
+    let data = ThreemaPayload::new(session, affiliation, version);
     if let Err(e) = payload.add_custom_data(PAYLOAD_KEY, &data) {
         return Box::new(future::err(SendPushError::Other(format!(
             "Could not add custom data to APNs payload: {}",

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -72,11 +72,12 @@ pub fn send_push(
     push_token: &FcmToken,
     version: u16,
     session: &str,
+    affiliation: Option<&str>,
     collapse_key: Option<&str>,
     priority: Priority,
     ttl: u32,
 ) -> SendFuture<(), SendPushError> {
-    let data = ThreemaPayload::new(session, version);
+    let data = ThreemaPayload::new(session, affiliation, version);
     let payload = Payload {
         to: &push_token.0,
         collapse_key,

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -34,6 +34,8 @@ impl PushToken {
 struct ThreemaPayload<'a> {
     /// Session id (public key of the initiator)
     wcs: &'a str,
+    /// Affiliation id
+    wca: Option<&'a str>,
     /// Timestamp
     wct: i64,
     /// Version
@@ -41,9 +43,10 @@ struct ThreemaPayload<'a> {
 }
 
 impl<'a> ThreemaPayload<'a> {
-    pub fn new(session: &'a str, version: u16) -> Self {
+    pub fn new(session: &'a str, affiliation: Option<&'a str>, version: u16) -> Self {
         ThreemaPayload {
             wcs: session,
+            wca: affiliation,
             wct: Utc::now().timestamp(),
             wcv: version,
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::convert::Into;
 use std::net::SocketAddr;
 use std::ops::Deref;
@@ -251,6 +252,7 @@ impl Service for PushHandler {
                         return bad_request!("Invalid or missing parameters");
                     },
                 };
+                let affiliation = find!("affiliation").map(Cow::as_ref);
                 let ttl_string = find!("ttl")
                     .map(|ttl_str| ttl_str.trim().parse());
                 let ttl: u32 = match ttl_string {
@@ -290,6 +292,7 @@ impl Service for PushHandler {
                         token,
                         version,
                         &session_public_key,
+                        affiliation,
                         collapse_key.as_ref().map(String::as_str),
                         fcm::Priority::High,
                         ttl,
@@ -315,6 +318,7 @@ impl Service for PushHandler {
                         bundle_id.expect("bundle_id is None"),
                         version,
                         &session_public_key,
+                        affiliation,
                         collapse_id,
                         ttl,
                     ),


### PR DESCRIPTION
This is intended to be used to group consecutive pushes to be
associated to the same web client session's connection.