### PR TITLE
Change config file format from INI to TOML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,17 @@ Possible log types:
 - `[added]` for new features.
 - `[changed]` for changes in existing functionality.
 - `[deprecated]` for once-stable features removed in upcoming releases.
-- `[removed]` for deprecated features removed in this release.
+- `[removed]` for features removed in this release.
 - `[fixed]` for any bug fixes.
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
+
+### Unreleased
+
+- [changed] The config file format was changed from INI to TOML and the default
+  filename was changed from `config.ini` to `config.toml`. Since TOML is a
+  superset of INI, the existing config should remain valid. But the change
+  simplifies parsing and allows more data types (like lists and maps).
 
 ### [v3.4.0][v3.4.0] (2020-01-13)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,12 +43,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ahash"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,15 +394,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
-name = "dlv-list"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b391911b9a786312a10cb9d2b3d0735adfd5a8113eb3648de26a75e91b0826c"
-dependencies = [
- "rand 0.7.3",
-]
-
-[[package]]
 name = "dtoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,9 +590,6 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1100,16 +1082,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-multimap"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c672c7ad9ec066e428c00eb917124a06f08db19e2584de982cc34b1f4c12485"
-dependencies = [
- "dlv-list",
- "hashbrown",
-]
-
-[[package]]
 name = "owning_ref"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,12 +1252,12 @@ dependencies = [
  "mime",
  "mockito",
  "openssl",
- "rust-ini",
  "serde",
  "serde_derive",
  "serde_json",
  "thiserror",
  "tokio-core",
+ "toml",
  "url 2.2.1",
 ]
 
@@ -1584,16 +1556,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "untrusted",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b134767a87e0b086f73a4ce569ac9ce7d202f39c8eab6caa266e2617e73ac6"
-dependencies = [
- "cfg-if 0.1.10",
- "ordered-multimap",
 ]
 
 [[package]]
@@ -2146,6 +2108,15 @@ dependencies = [
  "tokio-codec",
  "tokio-io",
  "tokio-reactor",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ hyper-tls = "0.3"
 lazy_static = "1.3"
 log = "0.4"
 mime = "0.3"
-rust-ini = { version = "0.16", features = ["inline-comment"] }
 serde = "1.0.27"
 serde_derive = "1.0.27"
 serde_json = "1.0.10"
 thiserror = "1"
+toml = "0.5"
 tokio-core = "0.1"
 url = "2"
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ above.
 
 ## Running
 
-You need the Rust compiler (1.49 or higher). First, create a `config.ini` file
+You need the Rust compiler (1.49 or higher). First, create a `config.toml` file
 that looks like this:
 
     [fcm]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,42 @@
+//! Configuration.
+
+use std::{fs::File, io::Read, path::Path};
+
+use serde_derive::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    pub fcm: FcmConfig,
+    pub apns: ApnsConfig,
+    pub influxdb: Option<InfluxdbConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FcmConfig {
+    pub api_key: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ApnsConfig {
+    pub keyfile: String,
+    pub key_id: String,
+    pub team_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct InfluxdbConfig {
+    pub connection_string: String,
+    pub user: String,
+    pub pass: String,
+    pub db: String,
+}
+
+impl Config {
+    pub fn load(path: &Path) -> Result<Config, String> {
+        let mut file = File::open(path).map_err(|e| e.to_string())?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)
+            .map_err(|e| e.to_string())?;
+        Ok(toml::from_str(&contents).map_err(|e| e.to_string())?)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,18 +19,17 @@ extern crate log;
 
 #[macro_use]
 mod utils;
+mod config;
 mod errors;
 mod influxdb;
 mod push;
 mod server;
 
-use std::fs::File;
-use std::io::Read;
-use std::net::SocketAddr;
-use std::process;
+use std::{fs::File, io::Read, net::SocketAddr, path::Path, process};
 
 use clap::{App, Arg};
-use ini::Ini;
+
+use config::Config;
 
 const NAME: &str = "push-relay";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -55,7 +54,7 @@ fn main() {
                 .short("c")
                 .long("config")
                 .value_name("path")
-                .help("Path to a configfile. Default: config.ini."),
+                .help("Path to a configfile. Default: config.toml."),
         )
         .get_matches();
 
@@ -65,81 +64,19 @@ fn main() {
         process::exit(1);
     });
 
-    let configfile = matches.value_of("config").unwrap_or("config.ini");
+    let configfile = matches.value_of("config").unwrap_or("config.toml");
 
     // Load config file
-    let config = Ini::load_from_file(configfile).unwrap_or_else(|e| {
-        error!("Could not open config file: {}", e);
-        process::exit(1);
-    });
-
-    // Determine FCM API key
-    let config_fcm = config.section(Some("fcm".to_owned())).unwrap_or_else(|| {
-        error!("Invalid config file: No [fcm] section in {}", configfile);
-        process::exit(2);
-    });
-    let fcm_api_key = config_fcm.get("api_key").unwrap_or_else(|| {
-        error!(
-            "Invalid config file: No 'api_key' key in [fcm] section in {}",
-            configfile
-        );
+    let config = Config::load(Path::new(configfile)).unwrap_or_else(|e| {
+        error!("Could not load config file '{}': {}", configfile, e);
         process::exit(2);
     });
 
-    // Determine APNs config
-    let config_apns = config.section(Some("apns".to_owned())).unwrap_or_else(|| {
-        error!("Invalid config file: No [apns] section in {}", configfile);
-        process::exit(2);
-    });
-    let apns_keyfile_path = config_apns.get("keyfile").unwrap_or_else(|| {
-        error!(
-            "Invalid config file: No 'keyfile' key in [apns] section in {}",
-            configfile
-        );
-        process::exit(2);
-    });
-    let apns_team_id = config_apns.get("team_id").unwrap_or_else(|| {
-        error!(
-            "Invalid config file: No 'team_id' key in [apns] section in {}",
-            configfile
-        );
-        process::exit(2);
-    });
-    let apns_key_id = config_apns.get("key_id").unwrap_or_else(|| {
-        error!(
-            "Invalid config file: No 'key_id' key in [apns] section in {}",
-            configfile
-        );
-        process::exit(2);
-    });
-
-    // Determine InfluxDB config
-    let influxdb = config.section(Some("influxdb".to_owned())).map(|c| {
-        influxdb::Influxdb::init(
-            c.get("connection_string").unwrap_or_else(|| {
-                error!("Invalid config file: No 'connection_string' key in [influxdb] secttion in {}", configfile);
-                process::exit(3);
-            }).to_owned(),
-            c.get("user").unwrap_or_else(|| {
-                error!("Invalid config file: No 'user' key in [influxdb] secttion in {}", configfile);
-                process::exit(3);
-            }),
-            c.get("pass").unwrap_or_else(|| {
-                error!("Invalid config file: No 'pass' key in [influxdb] secttion in {}", configfile);
-                process::exit(3);
-            }),
-            c.get("db").unwrap_or_else(|| {
-                error!("Invalid config file: No 'db' key in [influxdb] secttion in {}", configfile);
-                process::exit(3);
-            }).to_owned(),
-        ).expect("Failed to create Influxdb instance")
-    });
-
-    // Open APNs keyfile
-    let mut apns_keyfile = File::open(apns_keyfile_path).unwrap_or_else(|e| {
+    // Open and read APNs keyfile
+    let mut apns_keyfile = File::open(&config.apns.keyfile).unwrap_or_else(|e| {
         error!(
             "Invalid 'keyfile' path: Could not open '{}': {}",
-            apns_keyfile_path, e
+            config.apns.keyfile, e
         );
         process::exit(3);
     });
@@ -149,21 +86,13 @@ fn main() {
         .unwrap_or_else(|e| {
             error!(
                 "Invalid 'keyfile': Could not read '{}': {}",
-                apns_keyfile_path, e
+                config.apns.keyfile, e
             );
             process::exit(3);
         });
 
     info!("Starting Push Relay Server {} on {}", VERSION, &addr);
-    server::serve(
-        fcm_api_key,
-        &apns_api_key,
-        apns_team_id,
-        apns_key_id,
-        addr,
-        influxdb,
-    )
-    .unwrap_or_else(|e| {
+    server::serve(config, &apns_api_key, addr).unwrap_or_else(|e| {
         error!("Could not start relay server: {}", e);
         process::exit(3);
     });


### PR DESCRIPTION
This simplifies parsing (because everything is now parsed with Serde)
and allows for more data types in the config file (like lists and maps).
It also reduces the total dependency count by 10.

The default filename was changed from `config.ini` to `config.toml`.
Since TOML is a superset of INI, the existing config should remain
valid.