### PR TITLE
Config: Allow missing hms section

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use serde_derive::Deserialize;
 pub struct Config {
     pub fcm: FcmConfig,
     pub apns: ApnsConfig,
-    pub hms: HashMap<String, HmsConfig>,
+    pub hms: Option<HashMap<String, HmsConfig>>,
     pub influxdb: Option<InfluxdbConfig>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,14 +74,17 @@ async fn main() {
     // Determine HMS credentials
     info!("Found FCM config");
     info!("Found APNs config");
-    if config.hms.is_empty() {
-        warn!("No HMS credentials found in config, HMS pushes cannot be handled");
-    } else {
-        info!(
-            "Found {} HMS config(s): {:?}",
-            config.hms.len(),
-            config.hms.keys().collect::<Vec<_>>()
-        );
+    match config.hms {
+        None => {
+            warn!("No HMS credentials found in config, HMS pushes cannot be handled");
+        }
+        Some(ref map) if map.is_empty() => {
+            warn!("No HMS credentials found in config, HMS pushes cannot be handled");
+        }
+        Some(ref map) => {
+            let keys = map.keys().collect::<Vec<_>>();
+            info!("Found {} HMS config(s): {:?}", map.len(), keys);
+        }
     }
 
     // Open and read APNs keyfile

--- a/src/server.rs
+++ b/src/server.rs
@@ -51,6 +51,9 @@ pub async fn serve(
         influxdb,
     } = config;
 
+    // Convert missing hms config to empty HashMap
+    let hms = hms.unwrap_or_else(HashMap::new);
+
     // Create FCM HTTP client
     let fcm_client = http_client::make_client(90);
 


### PR DESCRIPTION
We need to use `Option<HashMap<...>>`, otherwise an empty table is required.