### PR TITLE
Change type of `project_id` to String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Possible log types:
 ### Unreleased
 
 - [changed] Bump rust toolchain to 1.86
+- [changed] Change type of `project_id` to String
 
 ### [5.0.4][v5.0.4] (2025-05-16)
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,7 +45,7 @@ impl<S: Into<Vec<u8>>> From<S> for FcmApplicationSecret {
 pub struct FcmConfig {
     #[serde(rename = "service_account_key_base64")]
     pub service_account_key: FcmApplicationSecret,
-    pub project_id: u64,
+    pub project_id: String,
     pub max_retries: u8,
 }
 

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -86,14 +86,14 @@ pub struct FcmEndpointConfig {
     endpoint: String,
 }
 
-fn get_fcm_uri(project_id: u64, fcm_authority: impl AsRef<str>) -> String {
+fn get_fcm_uri(project_id: &str, fcm_authority: impl AsRef<str>) -> String {
     let base_url = fcm_authority.as_ref();
     format!("{base_url}/v1/projects/{project_id}/messages:send")
 }
 
 impl FcmEndpointConfig {
     fn new(config: &config::FcmConfig, fcm_authority: impl AsRef<str>) -> Self {
-        let endpoint = get_fcm_uri(config.project_id, fcm_authority);
+        let endpoint = get_fcm_uri(&config.project_id, fcm_authority);
         Self {
             max_retries: config.max_retries,
             endpoint,
@@ -450,7 +450,7 @@ pub mod test {
     use super::*;
 
     pub fn get_fcm_test_path(config: &config::FcmConfig) -> String {
-        get_fcm_uri(config.project_id, "")
+        get_fcm_uri(&config.project_id, "")
     }
 
     #[derive(Clone)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -543,7 +543,7 @@ mod tests {
     fn get_test_fcm_config() -> FcmConfig {
         FcmConfig {
             service_account_key: b"yolo".into(),
-            project_id: 12345678,
+            project_id: "12345678".to_string(),
             max_retries: get_test_max_retries(),
         }
     }


### PR DESCRIPTION
Since the project_id is user-defined, it can also be a string: https://firebase.google.com/docs/projects/learn-more#project-id
Closes #68 